### PR TITLE
fix: duplicate 'buildPyRuntime' within package

### DIFF
--- a/poc.go
+++ b/poc.go
@@ -10,14 +10,14 @@ import (
 	_ "github.com/moby/buildkit/util/progress"
 )
 
-//installs the dependencies for metacall_base_runtime
+// installs the dependencies for metacall_base_runtime
 func builDeps(baseImg llb.State) llb.State {
 	deps := baseImg.Run(llb.Shlex("apt-get update")).
 		Run(llb.Shlex("apt-get install -y --no-install-recommends build-essential git cmake libgtest-dev wget apt-utils apt-transport-https gnupg dirmngr ca-certificates")).Root()
 	return deps
 }
 
-//builds metacall base runtime without any languages
+// builds metacall base runtime without any languages
 func buildmetacallbaseRuntime(depsImg llb.State) llb.State {
 	dev := depsImg.Run(llb.Shlex("git clone --depth 1 --single-branch --branch=develop https://github.com/metacall/core.git")).
 		Run(llb.Shlex("mkdir core/build")).
@@ -27,7 +27,7 @@ func buildmetacallbaseRuntime(depsImg llb.State) llb.State {
 	return dev
 }
 
-//builds metacall_python_runtime to support python scripts at runtime
+// builds metacall_python_runtime to support python scripts at runtime
 func buildMetacallPythonRuntime(metacallBaseRuntime llb.State) llb.State {
 	metacallPyRuntime := metacallBaseRuntime.Run(llb.Shlex("apt-get install -y --no-install-recommends python3-dev python3-pip")).
 		Run(llb.Shlex("cmake -DOPTION_BUILD_LOADERS_PY=On -DOPTION_BUILD_PORTS_PY=On ..")).
@@ -38,19 +38,19 @@ func buildMetacallPythonRuntime(metacallBaseRuntime llb.State) llb.State {
 //tests have been excluded for now
 //Run(llb.Shlexf("ctest -j %v --output-on-failure --test-output-size-failed 3221000000 -C Release", runtime.NumCPU())).
 
-//installs the runtime images
+// installs the runtime images
 func buildDevinstall(devImage llb.State) llb.State {
 	devInstall := devImage.Run(llb.Shlex("make install")).Root()
 	return devInstall
 }
 
-//installs python runtime dependencies
-func buildPyRuntime(baseupdateImg llb.State) llb.State {
+// installs python runtime dependencies
+func buildPyLib(baseupdateImg llb.State) llb.State {
 	pyruntime := baseupdateImg.Run(llb.Shlex("apt-get -y install --no-install-recommends libpython3.9")).Root()
 	return pyruntime
 }
 
-//to get the apt-get update layer segregated from the other
+// to get the apt-get update layer segregated from the other
 func buildBaseUpdate(baseImg llb.State) llb.State {
 	return baseImg.Run(llb.Shlex("apt-get update")).Root()
 }
@@ -70,7 +70,7 @@ func main() {
 	baseUpdate := buildBaseUpdate(base)
 
 	//contains addtional files that come with apt-get update
-	pyRuntimeDepsbuilt := buildPyRuntime(baseUpdate)
+	pyRuntimeDepsbuilt := buildPyLib(baseUpdate)
 
 	//contains only python runtime dependencies nothing else
 	pyRuntimeDeps := llb.Diff(baseUpdate, pyRuntimeDepsbuilt)


### PR DESCRIPTION
There are duplicate `buildPyRuntime` in `poc.go` and `main.go`